### PR TITLE
Switch from `Highlight` to `AccentColor` with fallback

### DIFF
--- a/pkg/frontend/src/main.scss
+++ b/pkg/frontend/src/main.scss
@@ -9,8 +9,30 @@ $pf-v6-global--image-path: "data-url:../node_modules/@patternfly/patternfly/asse
 @import "../node_modules/@patternfly/patternfly/patternfly-addons.scss";
 
 :root {
-  --pf-x-base-color: Highlight;
+  --pf-x-base-color: #0066cc;
+}
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pf-x-base-color: #92c5f9;
+  }
+}
+
+@supports (color: AccentColor) {
+  :root {
+    --pf-x-base-color: color-mix(in srgb, AccentColor 60%, black);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @supports (color: AccentColor) {
+    :root {
+      --pf-x-base-color: oklch(from AccentColor max(0.85, l) c h);
+    }
+  }
+}
+
+:root {
   --pf-t--global--color--brand--100: color-mix(
     in srgb,
     var(--pf-x-base-color) 80%,
@@ -22,6 +44,25 @@ $pf-v6-global--image-path: "data-url:../node_modules/@patternfly/patternfly/asse
     var(--pf-x-base-color) 80%,
     black
   );
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pf-t--global--color--brand--100: color-mix(
+      in srgb,
+      var(--pf-x-base-color) 80%,
+      black
+    );
+    --pf-t--global--color--brand--200: var(--pf-x-base-color);
+    --pf-t--global--color--brand--300: color-mix(
+      in srgb,
+      var(--pf-x-base-color) 80%,
+      white
+    );
+  }
+}
+
+:root {
   --pf-t--global--color--severity--none--100: var(
     --pf-t--global--color--brand--100
   );
@@ -34,7 +75,6 @@ $pf-v6-global--image-path: "data-url:../node_modules/@patternfly/patternfly/asse
   --pf-t--global--text--color--link--300: var(
     --pf-t--global--color--brand--300
   );
-
   --pf-t--global--dark--color--brand--100: color-mix(
     in srgb,
     var(--pf-x-base-color) 80%,
@@ -46,6 +86,25 @@ $pf-v6-global--image-path: "data-url:../node_modules/@patternfly/patternfly/asse
     var(--pf-x-base-color) 80%,
     black
   );
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --pf-t--global--dark--color--brand--100: color-mix(
+      in srgb,
+      var(--pf-x-base-color) 80%,
+      black
+    );
+    --pf-t--global--dark--color--brand--200: var(--pf-x-base-color);
+    --pf-t--global--dark--color--brand--300: color-mix(
+      in srgb,
+      var(--pf-x-base-color) 80%,
+      white
+    );
+  }
+}
+
+:root {
   --pf-t--global--dark--color--severity--none--100: var(
     --pf-t--global--dark--color--brand--100
   );
@@ -58,14 +117,6 @@ $pf-v6-global--image-path: "data-url:../node_modules/@patternfly/patternfly/asse
   --pf-t--global--dark--text--color--link--300: var(
     --pf-t--global--dark--color--brand--300
   );
-
-  --pf-v6-chart-axis--tick-label--Fill: var(
-    --pf-v6-c-content--blockquote--Color
-  );
-  --pf-v6-chart-container--cursor--line--Fill: var(
-    --pf-v6-c-content--blockquote--Color
-  );
-  --pf-v6-chart-global--label--Fill: var(--pf-v6-c-content--Color);
 }
 
 body,


### PR DESCRIPTION
This switches to the new [AccentColor](https://caniuse.com/mdn-css_types_color_system-color_accentcolor_accentcolortext) property, and includes a fallback for older browsers.